### PR TITLE
Allow specifying the admin password as a MD5 hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ HUB_USERNAME
 HUB_PASSWORD
 ```
 
+The password can either be provided as plain text or MD5 hashed.
+
 With the exporter running, hit the /metrics endpoint to collect metrics from the Home Hub. Here's a breakdown of available metrics.
 
 | Metrics Name           | Description   |

--- a/homehub-metrics-exporter.go
+++ b/homehub-metrics-exporter.go
@@ -24,7 +24,7 @@ func main() {
 	flag.StringVar(&listenAddress, "listen-address", envOrDefault("HUB_EXPORTER_LISTEN_ADDRESS", ":19092"), "Address that the metrics HTTP server will listen on")
 	flag.StringVar(&hubAddress, "hub-address", envOrDefault("HUB_ADDRESS", "192.168.1.254"), "Address for the Home Hub router")
 	flag.StringVar(&username, "hub-username", envOrDefault("HUB_USERNAME", "admin"), "Username for the Home Hub router")
-	flag.StringVar(&password, "hub-password", envOrDefault("HUB_PASSWORD", ""), "Password for the Home Hub router")
+	flag.StringVar(&password, "hub-password", envOrDefault("HUB_PASSWORD", ""), "Password for the Home Hub router, either plain text or MD5 hashed")
 	flag.Parse()
 
 	homehub := client.New("http://"+hubAddress, username, password)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -32,12 +33,21 @@ type HubClient struct {
 
 // New creates a new client
 func New(url string, userName string, password string) Client {
+	// MD5 hashes are 32 characters long
+	// A plain text password is maximum 20 characters long
+	if len(password) != 32 {
+		password = hexmd5(password)
+	} else {
+		// Make sure the MD5 hash is lowercase
+		password = strings.ToLower(password)
+	}
+
 	return &HubClient{
 		session: session{
 			url:          url,
 			apiURL:       url + "/" + homeHubAPIPath,
 			userName:     userName,
-			password:     hexmd5(password),
+			password:     password,
 			sessionID:    "0",
 			requestCount: 0,
 		},


### PR DESCRIPTION
The password is only used in the MD5 hashed version, so the hashing can be
skipped if the password already is provided as MD5 hash. This also makes it
more difficult to recover the admin password from any places where the
Home Hub Metrics Exporter is set up.