### PR TITLE
Add two new metrics for total bytes sent and receive over the internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ With the exporter running, hit the /metrics endpoint to collect metrics from the
 | bt_homehub_upload_rate_mbps | The upload rate of the Home Hub router |
 | bt_homehub_up | Whether the Home Hub is 'Up'. Will be 0 if the exporter failed to collect metrics. |
 | bt_homehub_uptime_seconds | The amount of time in seconds that the Home Hub has been running. |
+| bt_homehub_download_bytes_total | Total number of bytes downloaded from the internet. |
+| bt_homehub_upload_bytes_total | Total number of bytes uploaded to the internet. |
 
 ## Docker image
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -122,7 +122,7 @@ func (client *HubClient) GetSummaryStatistics() *Response {
 	}
 
 	var actions []action
-	xpaths := []string{ConnectedDevices, DownloadRate, FirmwareVersion, UploadRate, UpTime}
+	xpaths := []string{ConnectedDevices, DownloadedBytes, DownloadRate, FirmwareVersion, UploadedBytes, UploadRate, UpTime}
 
 	for i, xpath := range xpaths {
 		method := "getValue"

--- a/pkg/client/xpath.go
+++ b/pkg/client/xpath.go
@@ -5,10 +5,14 @@ const (
 	BandwidthMonitoring string = "Device/Services/BandwidthMonitoring"
 	// ConnectedDevices string constant for the Hosts request XPath expression
 	ConnectedDevices string = "Device/Hosts/Hosts"
+	// DownloadedBytes string constant for the BytesReceived request XPath expression
+	DownloadedBytes string = "Device/IP/Interfaces/Interface[@uid='3']/Stats/BytesReceived"
 	// DownloadRate string constant for the DownstreamCurrRate request XPath expression
 	DownloadRate string = "Device/DSL/Channels/Channel[@uid='1']/DownstreamCurrRate"
 	// FirmwareVersion string constant for the ExternalFirmwareVersion request XPath expression
 	FirmwareVersion string = "Device/DeviceInfo/ExternalFirmwareVersion"
+	// UploadedBytes string constant for the BytesSent request XPath expression
+	UploadedBytes string = "Device/IP/Interfaces/Interface[@uid='3']/Stats/BytesSent"
 	// UploadRate string constant for the UpstreamCurrRate request XPath expression
 	UploadRate string = "Device/DSL/Channels/Channel[@uid='1']/UpstreamCurrRate"
 	// UpTime string constant for the UpTime request XPath expression

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"log"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/jamesnetherton/homehub-metrics-exporter/pkg/client"
@@ -55,10 +56,20 @@ func (e *Exporter) Collect(channel chan<- prometheus.Metric) {
 								devices[device.macAddress] = device
 							}
 						}
+					case client.DownloadedBytes:
+						floatValue, err := strconv.ParseFloat(value.String(), 64)
+						if err == nil {
+							channel <- prometheus.MustNewConstMetric(e.metricDescriptions["downloadBytes"], prometheus.GaugeValue, floatValue)
+						}
 					case client.DownloadRate:
 						channel <- prometheus.MustNewConstMetric(e.metricDescriptions["downloadRateMbps"], prometheus.GaugeValue, value.Float())
 					case client.FirmwareVersion:
 						channel <- prometheus.MustNewConstMetric(e.metricDescriptions["build"], prometheus.GaugeValue, 1, value.String())
+					case client.UploadedBytes:
+						floatValue, err := strconv.ParseFloat(value.String(), 64)
+						if err == nil {
+							channel <- prometheus.MustNewConstMetric(e.metricDescriptions["uploadBytes"], prometheus.GaugeValue, floatValue)
+						}
 					case client.UploadRate:
 						channel <- prometheus.MustNewConstMetric(e.metricDescriptions["uploadRateMbps"], prometheus.GaugeValue, value.Float())
 					case client.UpTime:
@@ -118,5 +129,9 @@ func createMetricDescriptions() map[string]*prometheus.Desc {
 		prometheus.BuildFQName("bt", "homehub", "build_info"), "Route build information", []string{"firmware"}, nil)
 	metricDescriptions["up"] = prometheus.NewDesc(
 		prometheus.BuildFQName("bt", "homehub", "up"), "Whether the router is up", nil, nil)
+	metricDescriptions["downloadBytes"] = prometheus.NewDesc(
+		prometheus.BuildFQName("bt", "homehub", "download_bytes_total"), "Bytes downloaded from the internet", nil, nil)
+	metricDescriptions["uploadBytes"] = prometheus.NewDesc(
+		prometheus.BuildFQName("bt", "homehub", "upload_bytes_total"), "Bytes uploaded to the internet", nil, nil)
 	return metricDescriptions
 }

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -50,8 +50,10 @@ func TestMetricsScrapeSuccess(t *testing.T) {
 	bt_homehub_device_uploaded_megabytes{host_name="Host Name 4",ip_address="192.168.1.4",mac_address="AA:BB:CC:DD:EE:F4"} 30
 	bt_homehub_device_uploaded_megabytes{host_name="User Host Name 5",ip_address="192.168.1.5",mac_address="AA:BB:CC:DD:EE:F5"} 10
 	bt_homehub_device_uploaded_megabytes{host_name="User Host Name 6",ip_address="192.168.1.6",mac_address="AA:BB:CC:DD:EE:F6"} 100
+	bt_homehub_download_bytes_total 654321
 	bt_homehub_download_rate_mbps 123.45
 	bt_homehub_up 1
+	bt_homehub_upload_bytes_total 123456
 	bt_homehub_upload_rate_mbps 543.21
 	bt_homehub_uptime_seconds 9.8765421e+07`
 
@@ -173,6 +175,8 @@ func createResponseActions() []client.ResponseAction {
 	responseActions = append(responseActions, newResponseAction(client.UploadRate, 543.21))
 	responseActions = append(responseActions, newResponseAction(client.UpTime, 98765421.0))
 	responseActions = append(responseActions, newResponseAction(client.ConnectedDevices, createDevices()))
+	responseActions = append(responseActions, newResponseAction(client.DownloadedBytes, "654321"))
+	responseActions = append(responseActions, newResponseAction(client.UploadedBytes, "123456"))
 	return responseActions
 }
 


### PR DESCRIPTION
It allows you to see how much traffic has been put on the internet connection
compared to the `bt_homehub_device_*` metrics which also include internet
network traffic.

---

I extracted all the XPaths available on my router, they are available here
if it's of interest: https://gist.github.com/Tenzer/bcb0c01506317ba10aca65cb69928c74.