### PR TITLE
Remove fixed thresholds

### DIFF
--- a/etc/grafana/provisioning/dashboards/home-hub-dashboard.json
+++ b/etc/grafana/provisioning/dashboards/home-hub-dashboard.json
@@ -23,18 +23,13 @@
         "defaults": {
           "custom": {},
           "mappings": [],
-          "max": 100,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
                 "color": "green",
-                "value": 60
+                "value": null
               }
             ]
           },
@@ -163,18 +158,13 @@
               "type": 2
             }
           ],
-          "max": 25,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
                 "color": "green",
-                "value": 15
+                "value": null
               }
             ]
           },
@@ -573,12 +563,12 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "BT Home Hub Statistics",
   "uid": "dba8e3896e7a56b2325cc571fde93891",
-  "version": 14
+  "version": 15
 }


### PR DESCRIPTION
Realised there were fixed values in the gauge panels. Valid for my own hub, but totally inappropriate for anyone else's. Whilst they make the dashboard a bit prettier, they unfortunately don't make sense. This PR removes the warning range (because we can't calculate it) and the fixed max (because, the panel will default to the max value returned anyway).